### PR TITLE
[panic_handler]: use println! instead of crit!

### DIFF
--- a/common/crash-handler/src/lib.rs
+++ b/common/crash-handler/src/lib.rs
@@ -4,7 +4,6 @@
 #![forbid(unsafe_code)]
 
 use backtrace::Backtrace;
-use libra_logger::prelude::*;
 use serde::Serialize;
 use std::{
     panic::{self, PanicInfo},
@@ -35,7 +34,7 @@ fn handle_panic(panic_info: &PanicInfo<'_>) {
     let backtrace = format!("{:#?}", Backtrace::new());
 
     let info = CrashInfo { details, backtrace };
-    crit!("{}", toml::to_string_pretty(&info).unwrap());
+    println!("{}", toml::to_string_pretty(&info).unwrap());
 
     // Provide some time to save the log to disk
     thread::sleep(time::Duration::from_millis(100));


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Run local test panic. After check the crash log, I found the following:

```
Thread 1 Crashed:: run_test_channel_challenge_feature
0   test_channel_challenge-b2df05ac9d1909ac	0x000000010719c07b std::panicking::rust_panic_with_hook::h9db77b22c2255a16 + 139
1   test_channel_challenge-b2df05ac9d1909ac	0x00000001071ee57c std::panicking::begin_panic::h96314dd10caf8eef + 124 (panicking.rs:400)
2   test_channel_challenge-b2df05ac9d1909ac	0x0000000106d2840c _$LT$slog_scope..NoGlobalLoggerSet$u20$as$u20$slog..Drain$GT$::log::h7cf98eb24538e2c1 + 44
3   test_channel_challenge-b2df05ac9d1909ac	0x0000000106d1c218 _$LT$alloc..sync..Arc$LT$D$GT$$u20$as$u20$slog..Drain$GT$::log::h7e55b4fbe95d0917 + 56 (lib.rs:1689)
4   test_channel_challenge-b2df05ac9d1909ac	0x0000000106d1c18e slog::Logger$LT$D$GT$::log::h1403e644053605e8 + 46 (lib.rs:1204)
5   test_channel_challenge-b2df05ac9d1909ac	0x00000001045b2ade crash_handler::handle_panic::_$u7b$$u7b$closure$u7d$$u7d$::h1480b096b5d11356 + 366 (<::slog_scope::crit macros>:4)
6   test_channel_challenge-b2df05ac9d1909ac	0x00000001045b2038 slog_scope::with_logger::_$u7b$$u7b$closure$u7d$$u7d$::h3074c3259f1b5c1f + 376 (lib.rs:221)
7   test_channel_challenge-b2df05ac9d1909ac	0x00000001045b31a1 std::thread::local::LocalKey$LT$T$GT$::try_with::h6f70ff673da1a88a + 209 (local.rs:262)
8   test_channel_challenge-b2df05ac9d1909ac	0x00000001045b309d std::thread::local::LocalKey$LT$T$GT$::with::h2b12151ba291404c + 29 (local.rs:239)
9   test_channel_challenge-b2df05ac9d1909ac	0x00000001045b1eb4 slog_scope::with_logger::h3d661eb6464f7688 + 36 (lib.rs:224)
10  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b1ac9 crash_handler::handle_panic::hfe7bec663830ecf9 + 569 (lib.rs:38)
11  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b2969 crash_handler::setup_panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::hc06c25731721b563 + 25 (lib.rs:28)
12  test_channel_challenge-b2df05ac9d1909ac	0x000000010719c20c std::panicking::rust_panic_with_hook::h9db77b22c2255a16 + 540 (panicking.rs:471)
13  test_channel_challenge-b2df05ac9d1909ac	0x00000001071ee57c std::panicking::begin_panic::h96314dd10caf8eef + 124 (panicking.rs:400)
14  test_channel_challenge-b2df05ac9d1909ac	0x0000000106d2840c _$LT$slog_scope..NoGlobalLoggerSet$u20$as$u20$slog..Drain$GT$::log::h7cf98eb24538e2c1 + 44
15  test_channel_challenge-b2df05ac9d1909ac	0x0000000106d1c218 _$LT$alloc..sync..Arc$LT$D$GT$$u20$as$u20$slog..Drain$GT$::log::h7e55b4fbe95d0917 + 56 (lib.rs:1689)
16  test_channel_challenge-b2df05ac9d1909ac	0x0000000106d1c18e slog::Logger$LT$D$GT$::log::h1403e644053605e8 + 46 (lib.rs:1204)
17  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b2ade crash_handler::handle_panic::_$u7b$$u7b$closure$u7d$$u7d$::h1480b096b5d11356 + 366 (<::slog_scope::crit macros>:4)
18  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b2038 slog_scope::with_logger::_$u7b$$u7b$closure$u7d$$u7d$::h3074c3259f1b5c1f + 376 (lib.rs:221)
19  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b31a1 std::thread::local::LocalKey$LT$T$GT$::try_with::h6f70ff673da1a88a + 209 (local.rs:262)
20  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b309d std::thread::local::LocalKey$LT$T$GT$::with::h2b12151ba291404c + 29 (local.rs:239)
21  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b1eb4 slog_scope::with_logger::h3d661eb6464f7688 + 36 (lib.rs:224)
22  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b1ac9 crash_handler::handle_panic::hfe7bec663830ecf9 + 569 (lib.rs:38)
23  test_channel_challenge-b2df05ac9d1909ac	0x00000001045b2969 crash_handler::setup_panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::hc06c25731721b563 + 25 (lib.rs:28)
24  test_channel_challenge-b2df05ac9d1909ac	0x000000010719c20c std::panicking::rust_panic_with_hook::h9db77b22c2255a16 + 540 (panicking.rs:471)
25  test_channel_challenge-b2df05ac9d1909ac	0x000000010719bcc9 std::panicking::continue_panic_fmt::h2dfa3a5b90265361 + 169
26  test_channel_challenge-b2df05ac9d1909ac	0x00000001071f13cf std::panicking::begin_panic_fmt::h90396a215538fa8f + 79
27  test_channel_challenge-b2df05ac9d1909ac	0x0000000103a48aa1 test_channel_challenge::run_test_channel_challenge_feature::h8e71353a6d38461d + 241 (test_channel_challenge.rs:65)
28  test_channel_challenge-b2df05ac9d1909ac	0x0000000103a17161 test_channel_challenge::run_test_channel_challenge_feature::_$u7b$$u7b$closure$u7d$$u7d$::h2599d1a7c66de35f + 17 (test_channel_challenge.rs:32)
29  test_channel_challenge-b2df05ac9d1909ac	0x00000001039d0921 core::ops::function::FnOnce::call_once::h3a787b4ffded03f1 + 17 (function.rs:227)
30  test_channel_challenge-b2df05ac9d1909ac	0x0000000103a578fe _$LT$alloc..boxed..Box$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$A$GT$$GT$::call_once::h2a085a0a6f893c79 + 62 (boxed.rs:943)
31  test_channel_challenge-b2df05ac9d1909ac	0x00000001071a3f4f __rust_maybe_catch_panic + 31 (lib.rs:86)
32  test_channel_challenge-b2df05ac9d1909ac	0x0000000103a716a4 test::run_test::run_test_inner::_$u7b$$u7b$closure$u7d$$u7d$::hd9b4717441eeeb01 + 916 (lib.rs:570)
33  test_channel_challenge-b2df05ac9d1909ac	0x0000000103a4bd1b std::sys_common::backtrace::__rust_begin_short_backtrace::h0cd2655c68c16a7a + 43 (backtrace.rs:130)
34  test_channel_challenge-b2df05ac9d1909ac	0x0000000103a5015b std::panicking::try::do_call::h9e805d3a1637d454 + 43 (panicking.rs:289)
35  test_channel_challenge-b2df05ac9d1909ac	0x00000001071a3f4f __rust_maybe_catch_panic + 31 (lib.rs:86)
36  test_channel_challenge-b2df05ac9d1909ac	0x0000000103a50ba6 core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h222342df2877e946 + 134 (mod.rs:468)
37  test_channel_challenge-b2df05ac9d1909ac	0x000000010718cb8e _$LT$alloc..boxed..Box$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$A$GT$$GT$::call_once::h49b3841a036d0711 + 62 (boxed.rs:943)
38  test_channel_challenge-b2df05ac9d1909ac	0x00000001071a33ce std::sys::unix::thread::Thread::new::thread_start::hd9de55a9c1593989 + 142 (boxed.rs:943)
39  libsystem_pthread.dylib       	0x00007fff6c751e65 _pthread_start + 148
40  libsystem_pthread.dylib       	0x00007fff6c74d83b thread_start + 15

```

I figure out that after panic, the panic handler caught that, but fail to log it (using `crit!` in slog), but the action found no global logger set, and panic again!

This PR use `println!` to replace `crit!`, hope it can work.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
