### PR TITLE
abigen: support generate abi for module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "move-core-types 0.1.0",
  "move-prover 0.1.0",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "spec-lang 0.1.0",
  "test-utils 0.1.0",
 ]

--- a/language/move-prover/abigen/Cargo.toml
+++ b/language/move-prover/abigen/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.11"
 anyhow = "1.0.32"
 heck = "0.3.1"
 serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 codespan-reporting = "0.8.0"

--- a/language/move-prover/abigen/src/abigen.rs
+++ b/language/move-prover/abigen/src/abigen.rs
@@ -4,11 +4,16 @@
 #[allow(unused_imports)]
 use log::{debug, info, warn};
 
+use crate::module_abi::{
+    FuncArgumentABI, FuncDefinitionABI, ModuleABI, ReferenceABI, StructABI, StructDefinitionABI,
+    StructFieldABI, TypeABI,
+};
 use anyhow::bail;
 use heck::SnakeCase;
 use libra_types::transaction::{ArgumentABI, ScriptABI, TypeArgumentABI};
 use move_core_types::language_storage::TypeTag;
 use serde::{Deserialize, Serialize};
+use spec_lang::ty::PrimitiveType;
 use spec_lang::{
     env::{GlobalEnv, ModuleEnv},
     ty,
@@ -23,6 +28,8 @@ pub struct AbigenOptions {
     pub compiled_script_directory: String,
     /// In which directory to store output.
     pub output_directory: String,
+    /// whether gen abi for dependencies.
+    pub gen_deps: bool,
 }
 
 impl Default for AbigenOptions {
@@ -30,6 +37,7 @@ impl Default for AbigenOptions {
         Self {
             compiled_script_directory: ".".to_string(),
             output_directory: "abi".to_string(),
+            gen_deps: false,
         }
     }
 }
@@ -42,6 +50,7 @@ pub struct Abigen<'env> {
     env: &'env GlobalEnv,
     /// Map from file name to generated script ABI (if any).
     output: BTreeMap<String, ScriptABI>,
+    module_output: BTreeMap<String, ModuleABI>,
 }
 
 impl<'env> Abigen<'env> {
@@ -51,39 +60,63 @@ impl<'env> Abigen<'env> {
             options,
             env,
             output: Default::default(),
+            module_output: Default::default(),
         }
     }
 
     /// Returns the result of ABI generation, a vector of pairs of filenames
     /// and JSON content.
     pub fn into_result(mut self) -> Vec<(String, Vec<u8>)> {
+        let modules = std::mem::take(&mut self.module_output)
+            .into_iter()
+            .map(|(path, abi)| {
+                let content = serde_json::to_vec_pretty(&abi).expect("ABI to toml should not fail");
+                // let content = lcs::to_bytes(&abi).expect("ABI serialization should not fail");
+                (path, content)
+            });
         std::mem::take(&mut self.output)
             .into_iter()
             .map(|(path, abi)| {
                 let content = lcs::to_bytes(&abi).expect("ABI serialization should not fail");
                 (path, content)
             })
+            .chain(modules)
             .collect()
     }
 
     /// Generates ABIs for all script modules in the environment (excluding the dependency set).
     pub fn gen(&mut self) {
         for module in self.env.get_modules() {
-            if module.is_script_module() && !module.is_dependency() {
-                let mut path = PathBuf::from(&self.options.output_directory);
-                path.push(
-                    PathBuf::from(module.get_source_path())
-                        .with_extension("abi")
-                        .file_name()
-                        .expect("file name"),
-                );
+            if module.is_dependency() && !self.options.gen_deps {
+                continue;
+            }
+            let mut path = PathBuf::from(&self.options.output_directory);
+            path.push(
+                PathBuf::from(module.get_source_path())
+                    .with_extension("abi")
+                    .file_name()
+                    .expect("file name"),
+            );
 
+            if module.is_script_module() {
                 match self.compute_abi(&module) {
                     Ok(abi) => {
                         self.output.insert(path.to_string_lossy().to_string(), abi);
                     }
                     Err(error) => panic!(
                         "Error while processing script file {:?}: {}",
+                        module.get_source_path(),
+                        error
+                    ),
+                }
+            } else {
+                match self.compute_module_abi(&module) {
+                    Ok(abi) => {
+                        self.module_output
+                            .insert(path.to_string_lossy().to_string(), abi);
+                    }
+                    Err(error) => panic!(
+                        "Error while processing module file {:?}: {}",
                         module.get_source_path(),
                         error
                     ),
@@ -124,6 +157,148 @@ impl<'env> Abigen<'env> {
             )
             .collect::<anyhow::Result<_>>()?;
         Ok(ScriptABI::new(name, doc, code, ty_args, args))
+    }
+
+    fn type_to_type_abi(
+        &self,
+        ty0: ty::Type,
+        ty_args: &[TypeArgumentABI],
+    ) -> anyhow::Result<TypeABI> {
+        use ty::Type;
+        let abi = match ty0 {
+            Type::Primitive(p) => match p {
+                ty::PrimitiveType::U8 => TypeABI::U8,
+                PrimitiveType::Bool => TypeABI::Bool,
+                PrimitiveType::U64 => TypeABI::U64,
+                PrimitiveType::U128 => TypeABI::U128,
+                PrimitiveType::Address => TypeABI::Address,
+                PrimitiveType::Signer => TypeABI::Signer,
+                _ => {
+                    bail!("cannot gen type api for {}", p);
+                }
+            },
+            Type::Tuple(t) => {
+                let mut ts = vec![];
+                for ty in t {
+                    let type_abi = self.type_to_type_abi(ty, ty_args)?;
+                    ts.push(type_abi);
+                }
+                TypeABI::Tuple(ts)
+            }
+            Type::Vector(inner_type) => {
+                let t = self.type_to_type_abi(*inner_type, ty_args)?;
+                TypeABI::Vector(Box::new(t))
+            }
+            Type::Struct(mid, sid, tys) => {
+                let module_env = self.env.get_module(mid);
+                let symbol_pool = module_env.symbol_pool();
+                let struct_env = module_env.get_struct(sid);
+                let mut ty_params = vec![];
+                for t in tys {
+                    let t = self.type_to_type_abi(t, ty_args)?;
+                    ty_params.push(t);
+                }
+                let abi = StructABI {
+                    address: *module_env.self_address(),
+                    module: symbol_pool.string(module_env.get_name().name()).to_string(),
+                    name: symbol_pool.string(struct_env.get_name()).to_string(),
+                    ty_args: ty_params,
+                };
+                TypeABI::Struct(Box::new(abi))
+            }
+            Type::TypeParameter(idx) => {
+                TypeABI::TypeArgument(Box::new(ty_args[idx as usize].clone()))
+            }
+            Type::Reference(mutable, t) => {
+                let abi = ReferenceABI {
+                    mutable,
+                    ty: self.type_to_type_abi(*t, ty_args)?,
+                };
+                TypeABI::Reference(Box::new(abi))
+            }
+            _ => {
+                bail!("cannot gen type abi for {:?}", ty0);
+            }
+        };
+        Ok(abi)
+    }
+    fn compute_module_abi(&self, module_env: &ModuleEnv<'env>) -> anyhow::Result<ModuleABI> {
+        let symbol_pool = module_env.symbol_pool();
+        let mut struct_abis = vec![];
+        for s in module_env.get_structs() {
+            let ty_args: Vec<_> = s
+                .get_named_type_parameters()
+                .iter()
+                .map(|ty_param| {
+                    TypeArgumentABI::new(symbol_pool.string(ty_param.0).to_string().to_snake_case())
+                })
+                .collect();
+
+            let mut fields = vec![];
+            for f in s.get_fields() {
+                let ft = f.get_type();
+                let type_abi = self.type_to_type_abi(ft, &ty_args)?;
+                fields.push(StructFieldABI {
+                    name: symbol_pool.string(f.get_name()).to_string(),
+                    ty: type_abi,
+                })
+            }
+
+            let abi = StructDefinitionABI {
+                name: symbol_pool.string(s.get_name()).to_string(),
+                ty_args,
+                doc: s.get_doc().to_string(),
+                fields,
+            };
+            struct_abis.push(abi);
+        }
+        let mut func_abis = vec![];
+        for func in module_env.get_functions() {
+            // only output public functions.
+            if !func.is_public() {
+                continue;
+            }
+
+            let name = symbol_pool.string(func.get_name()).to_string();
+            let doc = func.get_doc().to_string();
+            let ty_args: Vec<_> = func
+                .get_named_type_parameters()
+                .iter()
+                .map(|ty_param| {
+                    TypeArgumentABI::new(symbol_pool.string(ty_param.0).to_string().to_snake_case())
+                })
+                .collect();
+
+            let mut args = vec![];
+            for p in func.get_parameters() {
+                let name = symbol_pool.string(p.0).to_string();
+                let ty = self.type_to_type_abi(p.1, &ty_args)?;
+                args.push(FuncArgumentABI { name, ty });
+            }
+            let mut rets = vec![];
+            for ret in func.get_return_types() {
+                rets.push(self.type_to_type_abi(ret, &ty_args)?);
+            }
+
+            func_abis.push(FuncDefinitionABI {
+                name,
+                doc,
+                ty_args,
+                args,
+                rets,
+            });
+        }
+
+        let name = symbol_pool.string(module_env.get_name().name()).to_string();
+        let address = *module_env.self_address();
+        let doc = module_env.get_doc().to_string();
+        Ok(ModuleABI {
+            address,
+            name,
+            doc,
+            structs: struct_abis,
+            funcs: func_abis,
+        })
     }
 
     fn load_compiled_bytes(&self, module_env: &ModuleEnv<'env>) -> anyhow::Result<Vec<u8>> {

--- a/language/move-prover/abigen/src/lib.rs
+++ b/language/move-prover/abigen/src/lib.rs
@@ -4,5 +4,5 @@
 #![forbid(unsafe_code)]
 
 mod abigen;
-
+mod module_abi;
 pub use crate::abigen::*;

--- a/language/move-prover/abigen/src/module_abi.rs
+++ b/language/move-prover/abigen/src/module_abi.rs
@@ -1,0 +1,79 @@
+use libra_types::transaction::TypeArgumentABI;
+use move_core_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ModuleABI {
+    pub address: AccountAddress,
+    pub name: String,
+    pub doc: String,
+    pub structs: Vec<StructDefinitionABI>,
+    pub funcs: Vec<FuncDefinitionABI>,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StructDefinitionABI {
+    pub name: String,
+    pub doc: String,
+    pub ty_args: Vec<TypeArgumentABI>,
+    pub fields: Vec<StructFieldABI>,
+}
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct FuncDefinitionABI {
+    pub name: String,
+    pub doc: String,
+    pub ty_args: Vec<TypeArgumentABI>,
+    pub args: Vec<FuncArgumentABI>,
+    pub rets: Vec<TypeABI>,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct FuncArgumentABI {
+    pub name: String,
+    pub ty: TypeABI,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StructFieldABI {
+    pub name: String,
+    pub ty: TypeABI,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub enum TypeABI {
+    Bool,
+    U8,
+    U64,
+    U128,
+    Address,
+    Signer,
+    Vector(Box<TypeABI>),
+    Struct(Box<StructABI>),
+    Tuple(Vec<TypeABI>),
+    TypeArgument(Box<TypeArgumentABI>),
+    Reference(Box<ReferenceABI>),
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub enum PrimitiveABI {
+    Bool,
+    U8,
+    U64,
+    U128,
+    Address,
+    Signer,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ReferenceABI {
+    pub mutable: bool,
+    pub ty: TypeABI,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StructABI {
+    pub address: AccountAddress,
+    pub name: String,
+    pub module: String,
+    pub ty_args: Vec<TypeABI>,
+}


### PR DESCRIPTION
cd into move-prover and run:

`cargo run -- --abigen -C 'abigen.compiled_script_directory="../stdlib/compiled/latest/transaction_scripts"' ../stdlib/modules/`

This will output module abi of stdlib into *abi* directory.