### PR TITLE
return type_tag instead of typelayout

### DIFF
--- a/language/move-vm/natives/src/token.rs
+++ b/language/move-vm/natives/src/token.rs
@@ -1,4 +1,4 @@
-use move_core_types::language_storage::{TypeTag, StructTag};
+use move_core_types::language_storage::TypeTag;
 use move_vm_types::{
     gas_schedule::NativeCostIndex,
     loaded_data::runtime_types::Type,
@@ -7,8 +7,6 @@ use move_vm_types::{
 };
 use std::collections::VecDeque;
 use vm::errors::PartialVMResult;
-use move_core_types::account_address::AccountAddress;
-use move_core_types::identifier::Identifier;
 
 const DEFAULT_ERROR_CODE: u64 = 0x0ED2_5519;
 
@@ -25,7 +23,8 @@ pub fn native_token_name_of(
     let type_tag = context.type_to_type_tag(&ty_args[0])?;
     if let TypeTag::Struct(struct_tag) = type_tag {
         let mut name = struct_tag.name.as_bytes().to_vec();
-        let type_args_info = format_type_params(&struct_tag.type_params).expect("format should never fail");
+        let type_args_info =
+            format_type_params(&struct_tag.type_params).expect("format should never fail");
         name.append(&mut type_args_info.into_bytes());
         Ok(NativeResult::ok(
             cost,
@@ -58,20 +57,28 @@ fn format_type_params(type_params: &[TypeTag]) -> Result<String, std::fmt::Error
 
 #[test]
 fn test_type_params_formatting() {
+    use move_core_types::account_address::AccountAddress;
+    use move_core_types::identifier::Identifier;
+    use move_core_types::language_storage::StructTag;
     let a_struct = StructTag {
         address: AccountAddress::ZERO,
         module: Identifier::new("TestModule").unwrap(),
         name: Identifier::new("TestStruct").unwrap(),
-        type_params: vec![TypeTag::Address]
+        type_params: vec![TypeTag::Address],
     };
     let cases = vec![
         (vec![TypeTag::Address], "<Address>"),
-        (vec![TypeTag::Vector(Box::new(TypeTag::U8)), TypeTag::U64], "<Vector<U8>, U64>"),
-        (vec![TypeTag::U64, TypeTag::Struct(a_struct)], "<U64, 00000000000000000000000000000000::TestModule::TestStruct<Address>>")
+        (
+            vec![TypeTag::Vector(Box::new(TypeTag::U8)), TypeTag::U64],
+            "<Vector<U8>, U64>",
+        ),
+        (
+            vec![TypeTag::U64, TypeTag::Struct(a_struct)],
+            "<U64, 00000000000000000000000000000000::TestModule::TestStruct<Address>>",
+        ),
     ];
 
     for (ts, expected) in cases {
-
         let actual = format_type_params(&ts).unwrap();
         assert_eq!(&actual, expected);
     }

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -536,7 +536,7 @@ impl Loader {
         module_id: &ModuleId,
         ty_args: &[TypeTag],
         data_store: &mut impl DataStore,
-    ) -> VMResult<(Arc<Function>, Vec<Type>, Vec<MoveTypeLayout>)> {
+    ) -> VMResult<(Arc<Function>, Vec<Type>, Vec<TypeTag>)> {
         self.load_module_expect_no_missing_dependencies(module_id, data_store)?;
         let idx = self
             .module_cache
@@ -556,7 +556,7 @@ impl Loader {
 
         // type layout of returned value
         let module = self.get_module(module_id);
-        let mut layouts = vec![];
+        let mut type_tags = vec![];
         for token in func.return_.0.as_slice() {
             let ty = self
                 .module_cache
@@ -564,13 +564,13 @@ impl Loader {
                 .unwrap()
                 .make_type(module.module(), token)
                 .map_err(|e| e.finish(Location::Module(module_id.clone())))?;
-            let layout = self
-                .type_to_type_layout(&ty)
+            let type_tag = self
+                .type_to_type_tag(&ty)
                 .map_err(|e| e.finish(Location::Module(module_id.clone())))?;
-            layouts.push(layout);
+            type_tags.push(type_tag);
         }
 
-        Ok((func, type_params, layouts))
+        Ok((func, type_params, type_tags))
     }
 
     // Entry point for module publishing (`MoveVM::publish_module`).

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -12,7 +12,6 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
-    value::MoveTypeLayout,
     vm_status::StatusCode,
 };
 use move_vm_types::{data_store::DataStore, gas_schedule::CostStrategy, values::Value};
@@ -156,10 +155,10 @@ impl VMRuntime {
         args: Vec<Value>,
         data_store: &mut impl DataStore,
         cost_strategy: &mut CostStrategy,
-    ) -> VMResult<Vec<(MoveTypeLayout, Value)>> {
+    ) -> VMResult<Vec<(TypeTag, Value)>> {
         // load the function in the given module, perform verification of the module and
         // its dependencies if the module was not loaded
-        let (func, type_params, returned_type_layouts) =
+        let (func, type_params, return_type_tags) =
             self.loader
                 .load_function(function_name, module, &ty_args, data_store)?;
 
@@ -176,7 +175,7 @@ impl VMRuntime {
             &self.loader,
         )?;
 
-        let result: Vec<_> = returned_type_layouts
+        let result: Vec<_> = return_type_tags
             .into_iter()
             .zip(returned_value.into_iter())
             .collect();

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -10,7 +10,6 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
-    value::MoveTypeLayout,
     vm_status::VMStatus,
 };
 use move_vm_types::data_store::DataStore;
@@ -55,7 +54,7 @@ impl<'r, 'l, R: RemoteCache> Session<'r, 'l, R> {
         _sender: AccountAddress,
         cost_strategy: &mut CostStrategy,
         error_specializer: F,
-    ) -> Result<Vec<(MoveTypeLayout, Value)>, VMStatus> {
+    ) -> Result<Vec<(TypeTag, Value)>, VMStatus> {
         self.runtime
             .execute_readonly_function(
                 module,

--- a/language/move-vm/runtime/src/unit_tests/readonly_function_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/readonly_function_tests.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{data_cache::RemoteCache, move_vm::MoveVM};
+use move_core_types::language_storage::StructTag;
 use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
-    value::{MoveStructLayout, MoveTypeLayout},
 };
 use move_lang::{compiled_unit::CompiledUnit, shared::Address};
 use move_vm_types::gas_schedule::{zero_cost_schedule, CostStrategy};
@@ -57,7 +57,7 @@ impl Adapter {
         &self,
         module: &ModuleId,
         name: &Identifier,
-    ) -> Vec<(MoveTypeLayout, Value)> {
+    ) -> Vec<(TypeTag, Value)> {
         let cost_table = zero_cost_schedule();
         let mut cost_strategy = CostStrategy::system(&cost_table, GasUnits::new(0));
         let mut session = self.vm.new_session(&self.store);
@@ -136,24 +136,28 @@ fn readonly_func_call() -> PartialVMResult<()> {
     let module_id = ModuleId::new(WORKING_ACCOUNT, Identifier::new("A").unwrap());
     let name = Identifier::new("get_1").unwrap();
     let result = adapter.call_readonly_function(&module_id, &name);
-    assert!(result[0].0 == MoveTypeLayout::U64);
+    assert_eq!(result[0].0, TypeTag::U64);
     assert!(result[0].1.equals(&Value::u64(20))?);
 
     let module_id = ModuleId::new(WORKING_ACCOUNT, Identifier::new("A").unwrap());
     let name = Identifier::new("get_2").unwrap();
     let result = adapter.call_readonly_function(&module_id, &name);
-    assert!(result[0].0 == MoveTypeLayout::U64);
+    assert_eq!(result[0].0, TypeTag::U64);
     assert!(result[0].1.equals(&Value::u64(20))?);
-    assert!(result[1].0 == MoveTypeLayout::U64);
+    assert_eq!(result[1].0, TypeTag::U64);
     assert!(result[1].1.equals(&Value::u64(1))?);
 
     let module_id = ModuleId::new(WORKING_ACCOUNT, Identifier::new("A").unwrap());
     let name = Identifier::new("get_s").unwrap();
     let result = adapter.call_readonly_function(&module_id, &name);
     let value = Value::struct_(Struct::pack(vec![Value::u64(20)], false));
-    assert!(
-        result[0].0 == MoveTypeLayout::Struct(MoveStructLayout::new(vec![MoveTypeLayout::U64]))
-    );
+    let return_type_tag = TypeTag::Struct(StructTag {
+        address: AccountAddress::from_hex_literal("0x2").unwrap(),
+        module: Identifier::new("A").unwrap(),
+        name: Identifier::new("S").unwrap(),
+        type_params: vec![],
+    });
+    assert_eq!(result[0].0, return_type_tag);
     assert!(result[0].1.equals(&value)?);
 
     Ok(())


### PR DESCRIPTION
现在决定不用 abi 解析readonly funciton 的返回值，那么我们需要用 typetag 而不是 movelayout。
这个PR address 这个问题。